### PR TITLE
Fix for Apache Log4j vulnerability continue (CVE-2021-45046)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
         <!-- log -->
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.9</slf4j.version>
-        <log4j-api.version>2.15.0</log4j-api.version>
-        <log4j-core.version>2.15.0</log4j-core.version>
+        <log4j-api.version>2.16.0</log4j-api.version>
+        <log4j-core.version>2.16.0</log4j-core.version>
         <commons-logging.version>1.2</commons-logging.version>
 
         <!-- test dependencies -->


### PR DESCRIPTION
# Impact
The fix to address [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in a denial of service (DOS) attack.

# Mitigation
Log4j 2.16.0 fixes this issue by removing support for message lookup patterns and disabling JNDI functionality by default. This issue can be mitigated in prior releases (< 2.16.0) by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class).

Log4j 2.15.0 restricts JNDI LDAP lookups to localhost by default. Note that previous mitigations involving configuration such as to set the system property `log4j2.noFormatMsgLookup` to `true` do NOT mitigate this specific vulnerability.

### References
- [https://nvd.nist.gov/vuln/detail/CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046)
- [GHSA-jfh8-c2jp-5v3q](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
- [https://logging.apache.org/log4j/2.x/security.html](https://logging.apache.org/log4j/2.x/security.html)
- [https://www.openwall.com/lists/oss-security/2021/12/14/4](https://www.openwall.com/lists/oss-security/2021/12/14/4)