### PR TITLE
Fix error Null Pointer Exception when app start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <druid.version>1.1.16</druid.version>
         <c3p0.version>0.9.5.2</c3p0.version>
         <tomcat.jdbc.version>9.0.38</tomcat.jdbc.version>
+        <cglib.version>3.2.10</cglib.version>
     </properties>
 
     <dependencies>
@@ -202,6 +203,12 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
             <version>${tomcat.jdbc.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>${cglib.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/jd/jdbc/Executor.java
+++ b/src/main/java/com/jd/jdbc/Executor.java
@@ -368,7 +368,7 @@ public class Executor implements IExecute {
                 }
                 throw e;
             }
-            return new ExecuteResponse(plan.getStatementType(), new VtStreamResultSet(vtStream).reserve(maxRows));
+            return new ExecuteResponse(plan.getStatementType(), new VtStreamResultSet(vtStream, true).reserve(maxRows));
         };
     }
 

--- a/src/main/java/com/jd/jdbc/engine/ConcatenateEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/ConcatenateEngine.java
@@ -197,7 +197,7 @@ public class ConcatenateEngine implements PrimitiveEngine {
                 }
                 this.sourceStreamResultList = new ArrayList<>();
                 for (IExecute.VtStream source : sources) {
-                    VtStreamResultSet sourceStreamResultSet = new VtStreamResultSet(source);
+                    VtStreamResultSet sourceStreamResultSet = new VtStreamResultSet(source, true);
                     if (seenFields == null) {
                         seenFields = sourceStreamResultSet.getFields();
                     } else {

--- a/src/main/java/com/jd/jdbc/engine/JoinEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/JoinEngine.java
@@ -163,7 +163,7 @@ public class JoinEngine implements PrimitiveEngine {
                 Map<String, Query.BindVariable> joinVars = new HashMap<>();
                 VtResultSet resultSet = new VtResultSet();
 
-                VtStreamResultSet leftStreamResultSet = new VtStreamResultSet(this.leftStreamResult);
+                VtStreamResultSet leftStreamResultSet = new VtStreamResultSet(this.leftStreamResult, wantFields);
                 while (leftStreamResultSet.hasNext()) {
                     List<VtResultValue> leftRow = leftStreamResultSet.next();
                     for (Map.Entry<String, Integer> var : vars.entrySet()) {
@@ -171,7 +171,7 @@ public class JoinEngine implements PrimitiveEngine {
                     }
                     boolean rowSent = false;
                     this.rightStreamResult = right.streamExecute(ctx, vcursor, combineVars(bindValue, joinVars), wantFields);
-                    VtStreamResultSet rightStreamResultSet = new VtStreamResultSet(rightStreamResult);
+                    VtStreamResultSet rightStreamResultSet = new VtStreamResultSet(rightStreamResult, wantFields);
                     if (wantFields) {
                         // This code is currently unreachable because the first result
                         // will always be just the field info, which will cause the outer

--- a/src/main/java/com/jd/jdbc/engine/LimitEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/LimitEngine.java
@@ -99,7 +99,7 @@ public class LimitEngine implements PrimitiveEngine {
             IExecute.VtStream vtStream = this.input.streamExecute(ctx, vcursor, bindVariableMap, wantFields);
             LimitStream limitStream = new LimitStream(count, offset, vtStream);
             Integer maxRows = (Integer) ctx.getContextValue(VitessPropertyKey.MAX_ROWS.getKeyName());
-            VtRowList vtRowList = new VtStreamResultSet(limitStream).reserve(maxRows);
+            VtRowList vtRowList = new VtStreamResultSet(limitStream, wantFields).reserve(maxRows);
             List<List<VtResultValue>> rows = new ArrayList<>();
             while (vtRowList != null && vtRowList.hasNext()) {
                 List<VtResultValue> next = vtRowList.next();

--- a/src/main/java/com/jd/jdbc/engine/OrderedAggregateEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/OrderedAggregateEngine.java
@@ -179,7 +179,7 @@ public class OrderedAggregateEngine implements PrimitiveEngine, Truncater {
     public IExecute.VtStream streamExecute(IContext ctx, Vcursor vcursor, Map<String, Query.BindVariable> bindValues, boolean wantFields) throws SQLException {
         IExecute.VtStream vtStream = this.input.streamExecute(ctx, vcursor, bindValues, wantFields);
         return new IExecute.VtStream() {
-            private final VtStreamResultSet vtStreamResultSet = new VtStreamResultSet(vtStream);
+            private final VtStreamResultSet vtStreamResultSet = new VtStreamResultSet(vtStream, wantFields);
 
             private IExecute.VtStream stream = vtStream;
 

--- a/src/main/java/com/jd/jdbc/sqltypes/VtStreamResultSet.java
+++ b/src/main/java/com/jd/jdbc/sqltypes/VtStreamResultSet.java
@@ -41,14 +41,14 @@ public class VtStreamResultSet implements VtRowList {
 
     private int readRows = 0;
 
-    public VtStreamResultSet(IExecute.VtStream vtStream) {
+    public VtStreamResultSet(IExecute.VtStream vtStream, boolean wantFields) {
         this.vtStream = vtStream;
         if (vtStream == null) {
             return;
         }
 
         try {
-            fetched = vtStream.fetch(true);
+            fetched = vtStream.fetch(wantFields);
         } catch (SQLException e) {
             savedException = e;
             return;

--- a/src/test/java/com/jd/jdbc/concurrency/AllErrorRecorderTest.java
+++ b/src/test/java/com/jd/jdbc/concurrency/AllErrorRecorderTest.java
@@ -1,0 +1,89 @@
+package com.jd.jdbc.concurrency;
+
+import com.jd.jdbc.Executor;
+import com.jd.jdbc.context.IContext;
+import com.jd.jdbc.context.VtCancelContext;
+import com.jd.jdbc.context.VtContext;
+import com.jd.jdbc.vitess.VitessConnection;
+import com.jd.jdbc.vitess.VitessStatement;
+import com.jd.jdbc.vitess.mysql.VitessPropertyKey;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import testsuite.TestSuite;
+import testsuite.internal.TestSuiteShardSpec;
+
+public class AllErrorRecorderTest extends TestSuite {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testNull() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        VitessConnection conn = (VitessConnection) getConnection(Driver.of(TestSuiteShardSpec.TWO_SHARDS));
+        VitessStatement stmt = (VitessStatement) conn.createStatement();
+        stmt.executeUpdate("delete from user");
+        stmt.executeUpdate("insert into user (id, name) values (1, 'name1'), (2, 'name2'), (3, 'name3')");
+        stmt.close();
+
+        // 构造一个执行一次isDone就过期的context
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(VtCancelContext.class);
+        enhancer.setCallback(new MethodInterceptor() {
+            private int count;
+
+            @Override
+            public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+                if (method.getName().equals("isDone")) {
+                    count++;
+                    if (count > 1) {
+                        ((IContext) obj).cancel("dead line");
+                    }
+                }
+                return proxy.invokeSuper(obj, args);
+            }
+        });
+
+        Class[] argsClass = new Class[]{IContext.class, Map.class};
+        Object[] args = new Object[]{VtContext.withCancel(conn.getCtx()), new HashMap<>()};
+        IContext ctx = (IContext) enhancer.create(argsClass, args);
+        ctx.setContextValue(VitessPropertyKey.MAX_ROWS.getKeyName(),
+            Integer.valueOf(conn.getProperties().getProperty(VitessPropertyKey.MAX_ROWS.getKeyName(), "0")));
+
+        // 构造一个Statement, 拦截 executeQueryInternal 方法
+        enhancer = new Enhancer();
+        enhancer.setSuperclass(VitessStatement.class);
+        enhancer.setCallback(new MethodInterceptor() {
+            @Override
+            public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+                if (method.getName().equals("executeQueryInternal")) {
+                    // 用构造的 ctx 替换executeQueryInternal方法的第一个参数
+                    args[0] = ctx;
+                }
+                return proxy.invokeSuper(obj, args);
+            }
+        });
+        argsClass = new Class[]{VitessConnection.class, Executor.class};
+        args = new Object[]{conn, Executor.getInstance(null)};
+        VitessStatement stmt2 = (VitessStatement) enhancer.create(argsClass, args);
+
+        thrown.expect(java.sql.SQLException.class);
+        thrown.expectMessage("execution is cancelled. dead line");
+
+        ResultSet rs = stmt2.executeQuery("select id, name from user");
+        // 在 NativQueryService.execute 里被拦下来, 不会走到这一行
+        printNormal("columnCount: " + rs.getMetaData().getColumnCount());
+
+        rs.close();
+        stmt2.close();
+        conn.close();
+    }
+}


### PR DESCRIPTION
### Changes
* Add parameter "wangtFields" to VtStreamResultSet's constructor, avoiding unnecessary feilds query
* Add context timeout error recording

### Reason
Sepecify a small timeout value by calling `Statement.setQueryTimeout()`, context will timeout and then return to user normally with no error recorded, leading to NPE in the later ResultSetMetaData.getColumnCount call.