### PR TITLE
Optimize the time it takes to establish a connection when the app starts

### DIFF
--- a/src/main/java/com/jd/jdbc/discovery/HealthCheck.java
+++ b/src/main/java/com/jd/jdbc/discovery/HealthCheck.java
@@ -462,7 +462,7 @@ public enum HealthCheck {
             }
 
             try {
-                Thread.sleep(100);
+                Thread.sleep(50);
             } catch (InterruptedException e) {
 
             }

--- a/src/main/java/com/jd/jdbc/srvtopo/SrvTopo.java
+++ b/src/main/java/com/jd/jdbc/srvtopo/SrvTopo.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -91,14 +92,14 @@ public class SrvTopo {
      * @return
      * @throws SrvTopoException
      */
-    public static List<Query.Target> findAllTargets(IContext ctx, SrvTopoServer srvTopoServer, String cell, List<String> keyspaceNameList, List<Topodata.TabletType> tabletTypeList)
+    public static List<Query.Target> findAllTargets(IContext ctx, SrvTopoServer srvTopoServer, String cell, Set<String> keyspaceNameSet, List<Topodata.TabletType> tabletTypeList)
         throws InterruptedException, SQLException {
         List<Query.Target> targetList = new CopyOnWriteArrayList<>();
-        CountDownLatch countDownLatch = new CountDownLatch(keyspaceNameList.size());
+        CountDownLatch countDownLatch = new CountDownLatch(keyspaceNameSet.size());
         ReentrantLock lock = new ReentrantLock(true);
         AllErrorRecorder errRecorder = new AllErrorRecorder();
 
-        for (String keyspace : keyspaceNameList) {
+        for (String keyspace : keyspaceNameSet) {
             VtDaemonExecutorService.execute(() -> {
                 try {
                     // Get SrvKeyspace for cell/keyspace.

--- a/src/main/java/com/jd/jdbc/srvtopo/TabletGateway.java
+++ b/src/main/java/com/jd/jdbc/srvtopo/TabletGateway.java
@@ -29,7 +29,6 @@ import com.jd.jdbc.sqlparser.support.logging.LogFactory;
 import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,7 +109,7 @@ public class TabletGateway extends Gateway {
             return;
         }
         List<Query.Target> targetList = SrvTopo.findAllTargets(ctx, srvTopoServer, cell,
-            new ArrayList<>(noWatchedMap.values()), tabletTypeList);
+            new HashSet<>(noWatchedMap.values()), tabletTypeList);
         hc.waitForAllServingTablets(VtContext.withDeadline(ctx, 30, TimeUnit.SECONDS), Lists.newArrayList(targetList));
         noWatchedMap.forEach((cacheKey, v) -> this.tabletGatewayManager.add(cacheKey));
     }

--- a/src/main/java/com/jd/jdbc/topo/TopoConnection.java
+++ b/src/main/java/com/jd/jdbc/topo/TopoConnection.java
@@ -68,6 +68,8 @@ public interface TopoConnection extends Resource {
 
     CompletableFuture<ConnGetResponse> getFuture(IContext ctx, String filePath);
 
+    List<ConnGetResponse> getTabletsByCell(IContext ctx, String filePath) throws TopoException;
+
     /**
      * @param ctx
      * @param filePath

--- a/src/main/java/com/jd/jdbc/topo/TopoStatsConnection.java
+++ b/src/main/java/com/jd/jdbc/topo/TopoStatsConnection.java
@@ -58,6 +58,11 @@ public class TopoStatsConnection implements TopoConnection {
     }
 
     @Override
+    public List<ConnGetResponse> getTabletsByCell(IContext ctx, String filePath) throws TopoException {
+        return this.topoConnection.getTabletsByCell(ctx, filePath);
+    }
+
+    @Override
     public CompletableFuture<ConnGetResponse> getFuture(IContext ctx, String filePath) {
         return this.topoConnection.getFuture(ctx, filePath);
     }

--- a/src/main/java/com/jd/jdbc/topo/TopoTablet.java
+++ b/src/main/java/com/jd/jdbc/topo/TopoTablet.java
@@ -35,13 +35,15 @@ public interface TopoTablet {
 
     CompletableFuture<TopoTabletInfo> getTabletFuture(IContext ctx, Topodata.TabletAlias tabletAlias) throws TopoException;
 
+    List<TopoTabletInfo> getTabletsByRange(IContext ctx, String cell) throws TopoException;
+
     /**
      * @param ctx
      * @param cell
      * @return
      * @throws TopoException
      */
-    List<Topodata.TabletAlias> getTabletsByCell(IContext ctx, String cell) throws TopoException;
+    List<Topodata.TabletAlias> getTabletAliasByCell(IContext ctx, String cell) throws TopoException;
 
     CompletableFuture<List<Topodata.TabletAlias>> getTabletsByCellFuture(IContext ctx, String cell) throws TopoException;
 }

--- a/src/main/java/com/jd/jdbc/util/threadpool/AbstractVtExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/AbstractVtExecutorService.java
@@ -17,7 +17,7 @@ limitations under the License.
 package com.jd.jdbc.util.threadpool;
 
 public abstract class AbstractVtExecutorService {
-    public static final Integer DEFAULT_CORE_POOL_SIZE = Integer.min(10, Runtime.getRuntime().availableProcessors());
+    public static final Integer DEFAULT_CORE_POOL_SIZE = 10;
 
     public static final Integer DEFAULT_MAXIMUM_POOL_SIZE = DEFAULT_CORE_POOL_SIZE * 10;
 

--- a/src/main/java/com/jd/jdbc/util/threadpool/impl/VtHealthCheckExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/impl/VtHealthCheckExecutorService.java
@@ -35,7 +35,7 @@ public class VtHealthCheckExecutorService extends AbstractVtExecutorService {
 
     private volatile static ExecutorService executorService;
 
-    public static void initialize(Integer corePoolSize, Integer maximumPoolSize, Integer queueSzie, Long rejectedExecutionTimeoutMillis) {
+    public static void initialize(Integer corePoolSize, Integer maximumPoolSize, Integer queueSize, Long rejectedExecutionTimeoutMillis) {
         if (executorService == null) {
             synchronized (VtHealthCheckExecutorService.class) {
                 if (executorService == null) {
@@ -45,8 +45,8 @@ public class VtHealthCheckExecutorService extends AbstractVtExecutorService {
                     if (maximumPoolSize == null || maximumPoolSize <= 0 || maximumPoolSize < corePoolSize) {
                         maximumPoolSize = DEFAULT_MAXIMUM_POOL_SIZE;
                     }
-                    if (queueSzie == null || queueSzie <= 0) {
-                        queueSzie = DEFAULT_QUEUE_SIZE;
+                    if (queueSize == null || queueSize <= 0) {
+                        queueSize = DEFAULT_QUEUE_SIZE;
                     }
                     if (rejectedExecutionTimeoutMillis == null || rejectedExecutionTimeoutMillis <= 0) {
                         rejectedExecutionTimeoutMillis = DEFAULT_REJECTED_EXECUTION_TIMEOUT_MILLIS;
@@ -56,7 +56,7 @@ public class VtHealthCheckExecutorService extends AbstractVtExecutorService {
                         maximumPoolSize,
                         DEFAULT_KEEP_ALIVE_TIME_MILLIS,
                         TimeUnit.MILLISECONDS,
-                        new LinkedBlockingQueue<>(queueSzie),
+                        new LinkedBlockingQueue<>(queueSize),
                         VtThreadFactoryBuilder.build(QUERY_TASK_NAME_FORMAT),
                         new VtRejectedExecutionHandler(QUERY_TASK_NAME_FORMAT, rejectedExecutionTimeoutMillis));
 

--- a/src/main/java/com/jd/jdbc/vitess/VitessDriver.java
+++ b/src/main/java/com/jd/jdbc/vitess/VitessDriver.java
@@ -131,7 +131,9 @@ public class VitessDriver implements java.sql.Driver {
                 topoServer.getSrvKeyspace(globalContext, localCell, defaultKeyspace);
             } catch (TopoException e) {
                 if (e.getCode() == TopoExceptionCode.NO_NODE) {
-                    localCell = cells.get(1);
+                    if (cells.size() > 1) {
+                        localCell = cells.get(1);
+                    }
                 }
             }
             Set<String> ksSet = new HashSet<>(keySpaces);


### PR DESCRIPTION
### changes
* Optimize the time it takes to establish a connection when the app starts
* Avoid executing the same *keyspace* multiple times when *findAllTargets*;
* Reduced the sleep time of *waitForAllServingTablets*;
* The thread pool coreSize is changed to a fixed value of 10;
* When loadingTablets is performed on the *cell* for the first time, it is changed to obtain all the information at one time;