### PR TITLE
Optimize the logic of splitting multiQuery

### DIFF
--- a/src/main/java/com/jd/jdbc/sqlparser/utils/SplitMultiQueryUtils.java
+++ b/src/main/java/com/jd/jdbc/sqlparser/utils/SplitMultiQueryUtils.java
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 JD Project Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.sqlparser.utils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SplitMultiQueryUtils {
+    private static final char DEFAULT_CHAR = '0';
+
+    private static final Set<String> startCommentSet;
+
+    static {
+        startCommentSet = new HashSet();
+        startCommentSet.add("/*");
+        startCommentSet.add("#");
+        startCommentSet.add("--");
+        startCommentSet.add("//");
+    }
+
+    public static List<String> splitMulti(String sql) {
+        ArrayList<String> sqls = new ArrayList<>();
+        int beginPos = 0;
+        while (true) {
+            String nextSql = getNextSql(sql, beginPos);
+            if (StringUtils.isEmpty(nextSql)) {
+                return sqls;
+            }
+            sqls.add(nextSql);
+            beginPos += nextSql.length();
+        }
+    }
+
+    private static String getNextSql(String sql, int beginPos) {
+        int sqlLength = sql.length();
+        boolean escape = false;
+        char symbol = DEFAULT_CHAR;
+        if (beginPos >= sqlLength) {
+            return null;
+        }
+        int startStmtPos = getStatementBeginIndex(sql, beginPos);
+        if (startStmtPos >= sqlLength) {
+            return null;
+        }
+        for (int i = startStmtPos; i < sqlLength; i++) {
+            char var = sql.charAt(i);
+            switch (var) {
+                case ';':
+                    if (symbol == DEFAULT_CHAR) {
+                        return sql.substring(beginPos, i + 1);
+                    }
+                    escape = false;
+                    break;
+                case '\'':
+                case '"':
+                    if (!escape) {
+                        if (symbol == var) {
+                            symbol = DEFAULT_CHAR;
+                        } else if (symbol == DEFAULT_CHAR) {
+                            symbol = var;
+                        }
+                    }
+                    escape = false;
+                    break;
+                case '\\':
+                    escape = !escape;
+                    break;
+                default:
+                    escape = false;
+                    break;
+            }
+        }
+        return sql.substring(beginPos, sqlLength);
+    }
+
+    /**
+     * @param sql
+     * @param beginPos
+     * @return the position of the first character after the comment(skip whitespace)
+     */
+    public static int getStatementBeginIndex(String sql, int beginPos) {
+        int sqlLength = sql.length();
+        for (; beginPos < sqlLength; beginPos++) {
+            if (!Character.isWhitespace(sql.charAt(beginPos))) {
+                break;
+            }
+        }
+        int statementBeginIndex = beginPos;
+        do {
+            beginPos = statementBeginIndex;
+            switch (getCommentStart(sql, beginPos)) {
+                case "/*":
+                    statementBeginIndex = sql.indexOf("*/", beginPos + 2);
+                    if (statementBeginIndex == -1) {
+                        statementBeginIndex = beginPos;
+                    } else {
+                        statementBeginIndex += 2;
+                    }
+                    break;
+                case "#":
+                case "//":
+                case "--":
+                    statementBeginIndex = sql.indexOf('\n', beginPos + 1);
+                    if (statementBeginIndex == -1) {
+                        statementBeginIndex = sql.indexOf('\r', beginPos + 1);
+                        if (statementBeginIndex == -1) {
+                            statementBeginIndex = beginPos;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+            for (; statementBeginIndex < sqlLength; statementBeginIndex++) {
+                if (!Character.isWhitespace(sql.charAt(statementBeginIndex))) {
+                    break;
+                }
+            }
+        } while (statementBeginIndex != beginPos);
+        return statementBeginIndex;
+    }
+
+    private static String getCommentStart(String sql, int beginPos) {
+        for (String startComment : startCommentSet) {
+            if (StringUtils.startsWith(sql, startComment, beginPos)) {
+                return startComment;
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/jd/jdbc/sqlparser/utils/StringUtils.java
+++ b/src/main/java/com/jd/jdbc/sqlparser/utils/StringUtils.java
@@ -677,4 +677,27 @@ public class StringUtils {
 
         return replaceEach(result, searchList, replacementList, repeat, timeToLive - 1);
     }
+
+    /**
+     * @param searchIn
+     * @param searchFor
+     * @param startPos
+     * @return
+     */
+    public static boolean startsWith(String searchIn, String searchFor, int startPos) {
+        if (StringUtils.isEmpty(searchIn) || StringUtils.isEmpty(searchFor)) {
+            return false;
+        }
+        int searchForLength = searchFor.length();
+        int searchInLength = searchIn.length();
+        if (searchForLength > (searchInLength - startPos)) {
+            return false;
+        }
+        for (int i = 0; i < searchForLength; i++) {
+            if (searchFor.charAt(i) != searchIn.charAt(i + startPos)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/jd/jdbc/vitess/VitessStatement.java
+++ b/src/main/java/com/jd/jdbc/vitess/VitessStatement.java
@@ -18,7 +18,6 @@ limitations under the License.
 
 package com.jd.jdbc.vitess;
 
-import com.google.common.base.Splitter;
 import com.jd.jdbc.Executor;
 import com.jd.jdbc.context.IContext;
 import com.jd.jdbc.context.VtContext;
@@ -55,6 +54,8 @@ import com.jd.jdbc.sqlparser.parser.Lexer;
 import com.jd.jdbc.sqlparser.parser.ParserException;
 import com.jd.jdbc.sqlparser.support.logging.Log;
 import com.jd.jdbc.sqlparser.support.logging.LogFactory;
+import com.jd.jdbc.sqlparser.utils.SplitMultiQueryUtils;
+import com.jd.jdbc.sqlparser.utils.StringUtils;
 import com.jd.jdbc.sqlparser.utils.TableNameUtils;
 import com.jd.jdbc.sqlparser.utils.Utils;
 import com.jd.jdbc.sqltypes.VtResultSet;
@@ -613,7 +614,10 @@ public class VitessStatement extends AbstractVitessStatement {
     }
 
     protected List<String> split(String sql) throws SQLException {
-        List<String> sqls = new ArrayList<>(Splitter.on(";").omitEmptyStrings().trimResults().splitToList(sql));
+        if (StringUtils.isEmpty(sql)) {
+            throw new SQLException("trying to execute empty queries " + sql);
+        }
+        List<String> sqls = SplitMultiQueryUtils.splitMulti(sql);
         if (sqls.isEmpty()) {
             throw new SQLException("trying to execute empty queries " + sqls);
         }

--- a/src/test/java/com/jd/jdbc/util/SplitMultiQueryUtilsTest.java
+++ b/src/test/java/com/jd/jdbc/util/SplitMultiQueryUtilsTest.java
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 JD Project Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.util;
+
+import com.google.common.base.Splitter;
+import com.jd.jdbc.sqlparser.utils.SplitMultiQueryUtils;
+import java.io.IOException;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Assert;
+import org.junit.Test;
+import testsuite.TestSuite;
+import testsuite.internal.testcase.TestSuiteCase;
+
+public class SplitMultiQueryUtilsTest extends TestSuite {
+    private List<TestCase> testCaseList;
+
+    @Test
+    public void test01() {
+        StringBuilder sql = new StringBuilder();
+        int count = 100000;
+        for (int i = 0; i < 10; i++) {
+            sql.append("select * from user_extra;");
+        }
+        String inStr = sql.toString();
+        long begin, end;
+        begin = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            Splitter.on(";").omitEmptyStrings().trimResults().splitToList(inStr);
+        }
+        end = System.currentTimeMillis();
+        printNormal("VtDriver Splitter.on(\";\"): ");
+        printInfo((end - begin) + "mm");
+        begin = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            SplitMultiQueryUtils.splitMulti(inStr);
+        }
+        end = System.currentTimeMillis();
+        printNormal("Custom split method: ");
+        printInfo((end - begin) + "mm");
+        begin = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            Splitter.on(";").omitEmptyStrings().trimResults().splitToList(inStr);
+        }
+        end = System.currentTimeMillis();
+        printNormal("VtDriver Splitter.on(\";\")");
+        printInfo((end - begin) + "mm");
+        begin = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            SplitMultiQueryUtils.splitMulti(inStr);
+        }
+        end = System.currentTimeMillis();
+        printNormal("Custom split method: ");
+        printInfo((end - begin) + "mm");
+    }
+
+    @Test
+    public void test02() throws IOException {
+        initTestCase();
+        int i = 0;
+        List<String> rss;
+        for (TestCase testCase : testCaseList) {
+            i++;
+            printNormal("No." + i);
+            printNormal("Input:");
+            printInfo(testCase.getInitSql());
+            rss = SplitMultiQueryUtils.splitMulti(testCase.getInitSql());
+            Assert.assertEquals(testCase.getVerifyResult().size(), rss.size());
+            printNormal("Output:");
+            for (int j = 0; j < rss.size(); j++) {
+                printInfo("expected:" + testCase.getVerifyResult().get(j));
+                printInfo("actual  :" + rss.get(j));
+                Assert.assertEquals(testCase.getVerifyResult().get(j), rss.get(j));
+            }
+        }
+    }
+
+    protected void initTestCase() throws IOException {
+        testCaseList = iterateExecFile("src/test/resources/util/splitmultiqueryutils.json", TestCase.class);
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    protected static class TestCase extends TestSuiteCase {
+        private String initSql;
+
+        private List<String> verifyResult;
+
+        private String errorMessage;
+    }
+}

--- a/src/test/java/com/jd/jdbc/vitess/allowMultiQueries/VitessDriverAllowMultiQuerieTest.java
+++ b/src/test/java/com/jd/jdbc/vitess/allowMultiQueries/VitessDriverAllowMultiQuerieTest.java
@@ -129,7 +129,7 @@ public class VitessDriverAllowMultiQuerieTest extends TestSuite {
 
     @Test
     public void groupBy() throws SQLException {
-        String sql = "select id from auto where id > 50 group by id order by id;;;;;select id from auto where id <= 50 group by id order by id;select id from auto group by id order by id;";
+        String sql = "select id from auto where id > 50 group by id order by id;select id from auto where id <= 50 group by id order by id;select id from auto group by id order by id;";
         try (Statement stmt = conn.createStatement()) {
             boolean hasResult = stmt.execute(sql);
             int sqlIdx = 0;

--- a/src/test/resources/util/splitmultiqueryutils.json
+++ b/src/test/resources/util/splitmultiqueryutils.json
@@ -1,0 +1,80 @@
+[
+  {
+    "comment": " \\n \\t ",
+    "initSql": "select * from table1; \t; \n; \n\t\t ; select * from table1;  ",
+    "verifyResult": [
+      "select * from table1;",
+      " \t;",
+      " \n;",
+      " \n\t\t ;",
+      " select * from table1;"
+    ],
+    "errorMessage": ""
+  },
+  {
+    "comment": "null sql",
+    "initSql": "",
+    "verifyResult": [
+    ]
+  },
+  {
+    "comment": "white space",
+    "initSql": "   ",
+    "verifyResult": [
+    ]
+  },
+  {
+    "comment": "all kinds of comment",
+    "initSql": "-- ; \n  select * from music; \n // ; \n /*123*/ #234\n -- bnmsd \n select * from user_extra;# ceshi \n select * from user;/*comment*/ select * from user_extra;",
+    "verifyResult": [
+      "-- ; \n  select * from music;",
+      " \n // ; \n /*123*/ #234\n -- bnmsd \n select * from user_extra;",
+      "# ceshi \n select * from user;",
+      "/*comment*/ select * from user_extra;"
+    ]
+  },
+  {
+    "comment": "special character in value",
+    "initSql": "  /*insert*/select * from user_extra where email = '\u001A';  /*insert*/select * from user_extra where email = '\u001A';  /*insert*/select * from user_extra where email = '¥';/*insert*/select * from user_extra where email = '\u00a5';/*insert*/select * from user_extra where email = '₩';/*insert*/select * from user_extra where email = '₩';  ",
+    "verifyResult": [
+      "  /*insert*/select * from user_extra where email = '\u001A';",
+      "  /*insert*/select * from user_extra where email = '\u001A';",
+      "  /*insert*/select * from user_extra where email = '¥';",
+      "/*insert*/select * from user_extra where email = '\u00a5';",
+      "/*insert*/select * from user_extra where email = '₩';",
+      "/*insert*/select * from user_extra where email = '₩';"
+    ]
+  },
+  {
+    "comment": "' ; \" \\ in value",
+    "initSql": "/*insert*/select * from user_extra where email = '单引号';/*insert*/select * from user_extra where email = \"双引号\";/*insert;*/ select * from user_extra where email = \"双引号\" and email = '单引号';/*insert*/select * from user_extra where email = \";\" and email = '\"';/*insert*/select * from user_extra where email = ';' and email = '\\'';select * from user_extra where email = \"\\';\\'\" and email = '\\'\\'';select * from user_extra where email = \"';'\" and email = '\\'\\\\';select * from user_extra where email = '内部双引号测试\"\\\"';/*comment*/select * from user_extra where email = \"内部单引号测试\"  ",
+    "verifyResult": [
+      "/*insert*/select * from user_extra where email = '单引号';",
+      "/*insert*/select * from user_extra where email = \"双引号\";",
+      "/*insert;*/ select * from user_extra where email = \"双引号\" and email = '单引号';",
+      "/*insert*/select * from user_extra where email = \";\" and email = '\"';",
+      "/*insert*/select * from user_extra where email = ';' and email = '\\'';",
+      "select * from user_extra where email = \"\\';\\'\" and email = '\\'\\'';",
+      "select * from user_extra where email = \"';'\" and email = '\\'\\\\';",
+      "select * from user_extra where email = '内部双引号测试\"\\\"';",
+      "/*comment*/select * from user_extra where email = \"内部单引号测试\"  "
+    ]
+  },
+  {
+    "comment": "single sql",
+    "initSql": "select * from user_extra;",
+    "verifyResult": [
+      "select * from user_extra;"
+    ]
+  },
+  {
+    "comment": "dml sql",
+    "initSql": "  insert into user(id, name) values (null, ';;;'); delete from user_extra;update engine_test set f_tinyint = 1 where f_key = '11';replace into unsharded_auto(val) values('aa');  ",
+    "verifyResult": [
+      "  insert into user(id, name) values (null, ';;;');",
+      " delete from user_extra;",
+      "update engine_test set f_tinyint = 1 where f_key = '11';",
+      "replace into unsharded_auto(val) values('aa');"
+    ]
+  }
+]


### PR DESCRIPTION
### changes
* The split(";") method is replaced by a custom split method (splitMulti)
* At present, the syntax parsing we use does not support comments in the middle of sql (select * /* comment */ from user), and this method of sql is not supported here.
* Neither Vitess nor mysql supports multiple semicolons in the middle of sql (select * from user;;; select * from user), which was previously supported by VtDriver, and the new split method is also modified to not support multiple semicolons in the middle