### PR TITLE
Set corePoolSize according to the number of cores of the machine

### DIFF
--- a/src/main/java/com/jd/jdbc/util/threadpool/AbstractVtExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/AbstractVtExecutorService.java
@@ -17,9 +17,17 @@ limitations under the License.
 package com.jd.jdbc.util.threadpool;
 
 public abstract class AbstractVtExecutorService {
-    public static final Integer DEFAULT_CORE_POOL_SIZE = 10;
+    public static final Integer DEFAULT_QUERY_CORE_POOL_SIZE = JdkUtil.getQueryExecutorCorePoolSize();
 
-    public static final Integer DEFAULT_MAXIMUM_POOL_SIZE = DEFAULT_CORE_POOL_SIZE * 10;
+    public static final Integer DEFAULT_DAEMON_CORE_POOL_SIZE = 10;
+
+    public static final Integer DEFAULT_HEALTH_CHECK_CORE_POOL_SIZE = 10;
+
+    public static final Integer DEFAULT_QUERY_MAXIMUM_POOL_SIZE = 100;
+
+    public static final Integer DEFAULT_DAEMON_MAXIMUM_POOL_SIZE = DEFAULT_DAEMON_CORE_POOL_SIZE * 10;
+
+    public static final Integer DEFAULT_HEALTH_MAXIMUM_POOL_SIZE = DEFAULT_HEALTH_CHECK_CORE_POOL_SIZE * 10;
 
     public static final Long DEFAULT_KEEP_ALIVE_TIME_MILLIS = 60 * 1000L;
 

--- a/src/main/java/com/jd/jdbc/util/threadpool/JdkUtil.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/JdkUtil.java
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 JD Project Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.util.threadpool;
+
+import com.jd.jdbc.sqlparser.utils.StringUtils;
+
+public class JdkUtil {
+    private static int queryExecutorCoreSize;
+
+    private static final int availableProcessors = Runtime.getRuntime().availableProcessors();
+
+    private static final int MAX_QUERY_EXECUTOR_CORE_SIZE = 32;
+
+    private static final int MIN_QUERY_EXECUTOR_CORE_SIZE = 8;
+
+    private static final int DEFAULT_QUERY_EXECUTOR_COLE_SIZE = 8;
+
+    private static final String applicationCurrentJdkVersion = System.getProperty("java.version");
+
+    private static final int[] catGetContainerCoreJdkArray = new int[] {1, 8, 0, 131};
+
+    static {
+        initQueryExecutorCorePoolSize();
+    }
+
+    /**
+     * If the current application is deployed in Docker, after jdk1.8.0_131,
+     * the number of Docker cores can be obtained by Runtime.getRuntime().availableProcessors()
+     */
+    private static boolean canGetContainerCoreByJdk() {
+        if (StringUtils.isEmpty(applicationCurrentJdkVersion) || !applicationCurrentJdkVersion.contains(".")) {
+            return false;
+        }
+        String[] applicationCurrentJdkArray = applicationCurrentJdkVersion.split("\\.|_");
+        int count = Math.min(applicationCurrentJdkArray.length, catGetContainerCoreJdkArray.length);
+        try {
+            for (int i = 0; i < count; i++) {
+                int applicationCurrentJdk = Integer.parseInt(applicationCurrentJdkArray[i]);
+                if (catGetContainerCoreJdkArray[i] == applicationCurrentJdk) {
+                    continue;
+                }
+                return catGetContainerCoreJdkArray[i] < applicationCurrentJdk;
+            }
+            return applicationCurrentJdkArray.length == catGetContainerCoreJdkArray.length;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Set the default number of core threads in the thread pool
+     * If the number of Docker cores cannot be obtained by the JDK version or JDK version number resolution failed,
+     * the number of core threads is set to MIN_QUERY_COLE_SIZE.
+     * If the number of Docker cores can be obtained by the JDK version:
+     * 1. The number of Docker cores < {@link #MIN_QUERY_EXECUTOR_CORE_SIZE}, the number of core threads is set to {@link #MIN_QUERY_EXECUTOR_CORE_SIZE}
+     * 2. The number of Docker cores > {@link #MAX_QUERY_EXECUTOR_CORE_SIZE}, the number of core threads is set to {@link #MAX_QUERY_EXECUTOR_CORE_SIZE}
+     * 3. The number of core threads is set to the number of Docker cores
+     */
+    private static void initQueryExecutorCorePoolSize() {
+        if (canGetContainerCoreByJdk()) {
+            if (availableProcessors < MIN_QUERY_EXECUTOR_CORE_SIZE) {
+                queryExecutorCoreSize = MIN_QUERY_EXECUTOR_CORE_SIZE;
+            } else {
+                queryExecutorCoreSize = Math.min(availableProcessors, MAX_QUERY_EXECUTOR_CORE_SIZE);
+            }
+        } else {
+            queryExecutorCoreSize = DEFAULT_QUERY_EXECUTOR_COLE_SIZE;
+        }
+    }
+
+    public static int getQueryExecutorCorePoolSize() {
+        return queryExecutorCoreSize;
+    }
+}

--- a/src/main/java/com/jd/jdbc/util/threadpool/impl/VtDaemonExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/impl/VtDaemonExecutorService.java
@@ -38,10 +38,13 @@ public class VtDaemonExecutorService extends AbstractVtExecutorService {
             synchronized (VtDaemonExecutorService.class) {
                 if (executorService == null) {
                     if (corePoolSize == null || corePoolSize <= 0) {
-                        corePoolSize = DEFAULT_CORE_POOL_SIZE;
+                        corePoolSize = DEFAULT_DAEMON_CORE_POOL_SIZE;
                     }
                     if (maximumPoolSize == null || maximumPoolSize <= 0 || maximumPoolSize < corePoolSize) {
-                        maximumPoolSize = DEFAULT_MAXIMUM_POOL_SIZE;
+                        maximumPoolSize = DEFAULT_DAEMON_MAXIMUM_POOL_SIZE;
+                        if (maximumPoolSize < corePoolSize) {
+                            maximumPoolSize += corePoolSize;
+                        }
                     }
                     if (rejectedExecutionTimeoutMillis == null || rejectedExecutionTimeoutMillis <= 0) {
                         rejectedExecutionTimeoutMillis = DEFAULT_REJECTED_EXECUTION_TIMEOUT_MILLIS;

--- a/src/main/java/com/jd/jdbc/util/threadpool/impl/VtHealthCheckExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/impl/VtHealthCheckExecutorService.java
@@ -40,10 +40,13 @@ public class VtHealthCheckExecutorService extends AbstractVtExecutorService {
             synchronized (VtHealthCheckExecutorService.class) {
                 if (executorService == null) {
                     if (corePoolSize == null || corePoolSize <= 0) {
-                        corePoolSize = DEFAULT_CORE_POOL_SIZE;
+                        corePoolSize = DEFAULT_HEALTH_CHECK_CORE_POOL_SIZE;
                     }
                     if (maximumPoolSize == null || maximumPoolSize <= 0 || maximumPoolSize < corePoolSize) {
-                        maximumPoolSize = DEFAULT_MAXIMUM_POOL_SIZE;
+                        maximumPoolSize = DEFAULT_HEALTH_MAXIMUM_POOL_SIZE;
+                        if (maximumPoolSize < corePoolSize) {
+                            maximumPoolSize += corePoolSize;
+                        }
                     }
                     if (queueSize == null || queueSize <= 0) {
                         queueSize = DEFAULT_QUEUE_SIZE;

--- a/src/main/java/com/jd/jdbc/util/threadpool/impl/VtQueryExecutorService.java
+++ b/src/main/java/com/jd/jdbc/util/threadpool/impl/VtQueryExecutorService.java
@@ -38,10 +38,13 @@ public class VtQueryExecutorService extends AbstractVtExecutorService {
             synchronized (VtQueryExecutorService.class) {
                 if (executorService == null) {
                     if (corePoolSize == null || corePoolSize <= 0) {
-                        corePoolSize = DEFAULT_CORE_POOL_SIZE;
+                        corePoolSize = DEFAULT_QUERY_CORE_POOL_SIZE;
                     }
                     if (maximumPoolSize == null || maximumPoolSize <= 0 || maximumPoolSize < corePoolSize) {
-                        maximumPoolSize = DEFAULT_MAXIMUM_POOL_SIZE;
+                        maximumPoolSize = DEFAULT_QUERY_MAXIMUM_POOL_SIZE;
+                        if (maximumPoolSize < corePoolSize) {
+                            maximumPoolSize += corePoolSize;
+                        }
                     }
                     if (queueSzie == null || queueSzie <= 0) {
                         queueSzie = DEFAULT_QUEUE_SIZE;

--- a/src/test/java/com/jd/jdbc/threadpool/VtThreadPoolExecutorTest.java
+++ b/src/test/java/com/jd/jdbc/threadpool/VtThreadPoolExecutorTest.java
@@ -30,7 +30,7 @@ public class VtThreadPoolExecutorTest extends TestSuite {
     public void testRejectedExecution() {
         printInfo("Test VtDriver thread pool executor rejected execution!");
         VtQueryExecutorService.initialize(null, null, null, null);
-        int max = AbstractVtExecutorService.DEFAULT_MAXIMUM_POOL_SIZE + AbstractVtExecutorService.DEFAULT_QUEUE_SIZE;
+        int max = AbstractVtExecutorService.DEFAULT_QUERY_MAXIMUM_POOL_SIZE + AbstractVtExecutorService.DEFAULT_QUEUE_SIZE;
         for (int i = 0; i < max; i++) {
             VtQueryExecutorService.execute(() -> {
                 try {

--- a/src/test/java/com/jd/jdbc/util/JdkUtilTest.java
+++ b/src/test/java/com/jd/jdbc/util/JdkUtilTest.java
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 JD Project Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.util;
+
+import com.jd.jdbc.util.threadpool.JdkUtil;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JdkUtilTest {
+
+    private List<JdkUtilNode> jdkUtilNodeList;
+
+    @Test
+    public void test00() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        initJdkData();
+        int i = 0;
+        for (JdkUtilNode jdkNode : jdkUtilNodeList) {
+            i++;
+            System.out.println("No. " + i);
+            System.out.println("JDK version: " + jdkNode.applicationCurrentJdkVersion
+                + " availableProcessors: " + jdkNode.availableProcessors
+                + " expectPoolCoreSize: " + jdkNode.expectPoolCoreSize
+                + " poolCoreSize: " + jdkNode.poolCoreSize);
+            Assert.assertEquals("Expected: " + jdkNode.expectPoolCoreSize + "; Actual: " + jdkNode.poolCoreSize, jdkNode.expectPoolCoreSize, jdkNode.poolCoreSize);
+        }
+        recoverJdkUtilVariable();
+    }
+
+    private void recoverJdkUtilVariable() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        new JdkUtilNode(System.getProperty("java.version"), Runtime.getRuntime().availableProcessors(), -1);
+    }
+
+    private void initJdkData() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        jdkUtilNodeList = new ArrayList<JdkUtilNode>();
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131", 10, 10));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 10, 10));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 6, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 36, 32));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_101", 10, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u131", 16, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u231", 16, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u231", 36, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131.1", 10, 8));
+        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131.1", 40, 8));
+    }
+
+    class JdkUtilNode {
+        private String applicationCurrentJdkVersion;
+
+        private int availableProcessors;
+
+        private int poolCoreSize;
+
+        private int expectPoolCoreSize;
+
+        JdkUtilNode(String applicationCurrentJdkVersion, int availableProcessors, int expectPoolCoreSize)
+            throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+            this.applicationCurrentJdkVersion = applicationCurrentJdkVersion;
+            this.availableProcessors = availableProcessors;
+            this.expectPoolCoreSize = expectPoolCoreSize;
+            setQueryCorePoolSize();
+        }
+
+        private void setQueryCorePoolSize() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+            Field applicationCurrentJdkVersionField = JdkUtil.class.getDeclaredField("applicationCurrentJdkVersion");
+            Field availableProcessorsField = JdkUtil.class.getDeclaredField("availableProcessors");
+            changeStaticFinal(applicationCurrentJdkVersionField, this.applicationCurrentJdkVersion);
+            changeStaticFinal(availableProcessorsField, this.availableProcessors);
+            Assert.assertEquals("Expected: " + this.applicationCurrentJdkVersion + "; Actual: " + applicationCurrentJdkVersionField.get(null), this.applicationCurrentJdkVersion,
+                applicationCurrentJdkVersionField.get(null));
+            Assert.assertEquals("Expected: " + this.availableProcessors + "; Actual: " + availableProcessorsField.get(null), this.availableProcessors, availableProcessorsField.get(null));
+            Method initQueryExecutorCorePoolSizeMethod = JdkUtil.class.getDeclaredMethod("initQueryExecutorCorePoolSize");
+            initQueryExecutorCorePoolSizeMethod.setAccessible(true);
+            initQueryExecutorCorePoolSizeMethod.invoke(null);
+            this.poolCoreSize = JdkUtil.getQueryExecutorCorePoolSize();
+        }
+
+        private void changeStaticFinal(Field field, Object value) throws NoSuchFieldException, IllegalAccessException {
+            field.setAccessible(true);
+            Field modiField = Field.class.getDeclaredField("modifiers");
+            modiField.setAccessible(true);
+            modiField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, value);
+        }
+    }
+}

--- a/src/test/java/com/jd/jdbc/util/JdkUtilTest.java
+++ b/src/test/java/com/jd/jdbc/util/JdkUtilTest.java
@@ -37,8 +37,7 @@ public class JdkUtilTest {
         for (JdkUtilNode jdkNode : jdkUtilNodeList) {
             i++;
             System.out.println("No. " + i);
-            System.out.println("JDK version: " + jdkNode.applicationCurrentJdkVersion
-                + " availableProcessors: " + jdkNode.availableProcessors
+            System.out.println(" availableProcessors: " + jdkNode.availableProcessors
                 + " expectPoolCoreSize: " + jdkNode.expectPoolCoreSize
                 + " poolCoreSize: " + jdkNode.poolCoreSize);
             Assert.assertEquals("Expected: " + jdkNode.expectPoolCoreSize + "; Actual: " + jdkNode.poolCoreSize, jdkNode.expectPoolCoreSize, jdkNode.poolCoreSize);
@@ -47,47 +46,35 @@ public class JdkUtilTest {
     }
 
     private void recoverJdkUtilVariable() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        new JdkUtilNode(System.getProperty("java.version"), Runtime.getRuntime().availableProcessors(), -1);
+        new JdkUtilNode(Runtime.getRuntime().availableProcessors(), -1);
     }
 
     private void initJdkData() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
         jdkUtilNodeList = new ArrayList<JdkUtilNode>();
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131", 10, 10));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 10, 10));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 6, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_191", 36, 32));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_101", 10, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u131", 16, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u231", 16, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0u231", 36, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131.1", 10, 8));
-        jdkUtilNodeList.add(new JdkUtilNode("1.8.0_131.1", 40, 8));
+        jdkUtilNodeList.add(new JdkUtilNode(10, 10));
+        jdkUtilNodeList.add(new JdkUtilNode(6, 8));
+        jdkUtilNodeList.add(new JdkUtilNode(36, 32));
+        jdkUtilNodeList.add(new JdkUtilNode(8, 8));
+        jdkUtilNodeList.add(new JdkUtilNode(32, 32));
     }
 
     class JdkUtilNode {
-        private String applicationCurrentJdkVersion;
-
         private int availableProcessors;
 
         private int poolCoreSize;
 
         private int expectPoolCoreSize;
 
-        JdkUtilNode(String applicationCurrentJdkVersion, int availableProcessors, int expectPoolCoreSize)
+        JdkUtilNode(int availableProcessors, int expectPoolCoreSize)
             throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-            this.applicationCurrentJdkVersion = applicationCurrentJdkVersion;
             this.availableProcessors = availableProcessors;
             this.expectPoolCoreSize = expectPoolCoreSize;
             setQueryCorePoolSize();
         }
 
         private void setQueryCorePoolSize() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-            Field applicationCurrentJdkVersionField = JdkUtil.class.getDeclaredField("applicationCurrentJdkVersion");
             Field availableProcessorsField = JdkUtil.class.getDeclaredField("availableProcessors");
-            changeStaticFinal(applicationCurrentJdkVersionField, this.applicationCurrentJdkVersion);
             changeStaticFinal(availableProcessorsField, this.availableProcessors);
-            Assert.assertEquals("Expected: " + this.applicationCurrentJdkVersion + "; Actual: " + applicationCurrentJdkVersionField.get(null), this.applicationCurrentJdkVersion,
-                applicationCurrentJdkVersionField.get(null));
             Assert.assertEquals("Expected: " + this.availableProcessors + "; Actual: " + availableProcessorsField.get(null), this.availableProcessors, availableProcessorsField.get(null));
             Method initQueryExecutorCorePoolSizeMethod = JdkUtil.class.getDeclaredMethod("initQueryExecutorCorePoolSize");
             initQueryExecutorCorePoolSizeMethod.setAccessible(true);


### PR DESCRIPTION
### Changes

* The corePoolSize of VtQueryExecutorService thread pools is set according to the number of cores in the machine
* Fixed a bug that the *corePoolSize* threads may be greater than the *maximumPoolSize* of threads during initialization

close #41 