### PR TITLE
【github】adjust TableQueryEngine，support parallel query for partitioned table

### DIFF
--- a/src/main/java/com/jd/jdbc/VcursorImpl.java
+++ b/src/main/java/com/jd/jdbc/VcursorImpl.java
@@ -166,4 +166,12 @@ public class VcursorImpl implements Vcursor {
         }
         return this.safeSession.getCharEncoding();
     }
+
+    @Override
+    public int getMaxParallelNum() {
+        if (this.safeSession == null) {
+            return 1;
+        }
+        return this.safeSession.getMaxParallelNum();
+    }
 }

--- a/src/main/java/com/jd/jdbc/common/Constant.java
+++ b/src/main/java/com/jd/jdbc/common/Constant.java
@@ -27,6 +27,8 @@ public class Constant {
 
     public static final String DRIVER_PROPERTY_ROLE_KEY = "role";
 
+    public static final String DRIVER_PROPERTY_QUERY_PARALLEL_NUM = "queryParallelNum";
+
     public static final String DRIVER_PROPERTY_ROLE_RW = "rw";
 
     public static final String DRIVER_PROPERTY_ROLE_RR = "rr";

--- a/src/main/java/com/jd/jdbc/discovery/SecurityCenter.java
+++ b/src/main/java/com/jd/jdbc/discovery/SecurityCenter.java
@@ -71,8 +71,8 @@ public enum SecurityCenter {
     @EqualsAndHashCode
     @AllArgsConstructor
     public class Credential {
-        private String user;
+        private final String user;
 
-        private String password;
+        private final String password;
     }
 }

--- a/src/main/java/com/jd/jdbc/engine/AbstractMultiQueryEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/AbstractMultiQueryEngine.java
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 JD Project Authors. Licensed under Apache-2.0.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.engine;
+
+import com.jd.jdbc.IExecute;
+import com.jd.jdbc.srvtopo.BindVariable;
+import com.jd.jdbc.srvtopo.BoundQuery;
+import com.jd.jdbc.srvtopo.ResolvedShard;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractMultiQueryEngine implements PrimitiveEngine {
+
+    protected final List<PrimitiveEngine> primitiveEngineList;
+
+    protected final List<IExecute.ResolvedShardQuery> shardQueryList;
+
+    protected final List<Map<String, BindVariable>> bindVariableMapList;
+
+    protected AbstractMultiQueryEngine(List<PrimitiveEngine> primitiveEngineList, List<IExecute.ResolvedShardQuery> shardQueryList,
+                                       List<Map<String, BindVariable>> bindVariableMapList) {
+        this.primitiveEngineList = primitiveEngineList;
+        this.shardQueryList = shardQueryList;
+        this.bindVariableMapList = bindVariableMapList;
+    }
+
+    @Override
+    public String getKeyspaceName() {
+        return null;
+    }
+
+    @Override
+    public String getTableName() {
+        return null;
+    }
+
+    protected IExecute.ExecuteBatchMultiShardResponse parallelShardsExecute(Vcursor vcursor, List<ResolvedShard> rss, List<List<BoundQuery>> queries) throws SQLException {
+        int sqlSize = 0;
+        for (List<BoundQuery> boundQueryList : queries) {
+            sqlSize += boundQueryList.size();
+        }
+        boolean autocommit = rss.size() == 1 && sqlSize == 1 && vcursor.autocommitApproval();
+        return vcursor.executeBatchMultiShard(rss, queries, true, autocommit);
+    }
+
+    protected Map<ResolvedShard, List<BoundQuery>> getResolvedShardListMap() {
+        Map<ResolvedShard, List<BoundQuery>> resolvedShardListMap = new HashMap<>(shardQueryList.size());
+
+        for (IExecute.ResolvedShardQuery resolvedShardQuery : shardQueryList) {
+            if (resolvedShardQuery == null) {
+                continue;
+            }
+            for (int i = 0; i < resolvedShardQuery.getRss().size(); i++) {
+                ResolvedShard resolvedShard = resolvedShardQuery.getRss().get(i);
+                BoundQuery boundQuery = resolvedShardQuery.getQueries().get(i);
+                resolvedShardListMap.computeIfAbsent(resolvedShard, k -> new ArrayList<>()).add(boundQuery);
+            }
+        }
+        return resolvedShardListMap;
+    }
+
+    @Override
+    public Boolean needsTransaction() {
+        for (PrimitiveEngine primitiveEngine : primitiveEngineList) {
+            if (primitiveEngine.needsTransaction()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/jd/jdbc/engine/Vcursor.java
+++ b/src/main/java/com/jd/jdbc/engine/Vcursor.java
@@ -87,4 +87,6 @@ public interface Vcursor {
     Boolean getRollbackOnPartialExec();
 
     String getCharEncoding();
+
+    int getMaxParallelNum();
 }

--- a/src/main/java/com/jd/jdbc/engine/table/TableInsertEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/table/TableInsertEngine.java
@@ -179,7 +179,7 @@ public class TableInsertEngine implements PrimitiveEngine {
         List<IExecute.ResolvedShardQuery> shardQueryList = new ArrayList<>();
         List<PrimitiveEngine> sourceList = new ArrayList<>();
         List<Map<String, BindVariable>> batchBindVariableMap = new ArrayList<>();
-        Map<String, LogicTable> shardTableLTMap = new HashMap<>();
+        Map<String, String> shardTableLTMap = new HashMap<>();
 
         List<VtPlanValue> tempRouteValueList = new ArrayList<>();
         List<VtPlanValue> bList = new ArrayList<>();
@@ -188,7 +188,7 @@ public class TableInsertEngine implements PrimitiveEngine {
 
         for (int i = 0; i < actualTables.size(); i++) {
             ActualTable actualTable = actualTables.get(i);
-            shardTableLTMap.put(actualTable.getActualTableName(), actualTable.getLogicTable());
+            shardTableLTMap.put(actualTable.getActualTableName(), actualTable.getLogicTable().getLogicTable());
             List<Query.Value> indexes = indexesPerTable.get(i);
             List<VtPlanValue> tempInnerPlanValueList = new ArrayList<>();
             List<SQLInsertStatement.ValuesClause> valuesClauseList = new ArrayList<>();
@@ -208,8 +208,8 @@ public class TableInsertEngine implements PrimitiveEngine {
             sourceList.add(this.insertEngine);
             batchBindVariableMap.add(bindVariableMap);
         }
-        PrimitiveEngine primitive = MultiQueryPlan.buildMultiQueryPlan(sourceList, shardQueryList, batchBindVariableMap);
-        VtResultSet resultSet = Engine.execCollectMultQueries(ctx, primitive, vcursor, wantField, shardTableLTMap);
+        PrimitiveEngine primitive = MultiQueryPlan.buildTableQueryPlan(sourceList, shardQueryList, batchBindVariableMap, shardTableLTMap);
+        VtResultSet resultSet = Engine.execCollectMultQueries(ctx, primitive, vcursor, wantField);
         return new IExecute.ExecuteMultiShardResponse(resultSet).setUpdate();
     }
 

--- a/src/main/java/com/jd/jdbc/engine/table/TableQueryEngine.java
+++ b/src/main/java/com/jd/jdbc/engine/table/TableQueryEngine.java
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 JD Project Authors. Licensed under Apache-2.0.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.jd.jdbc.engine.table;
+
+import com.google.common.collect.Lists;
+import com.jd.jdbc.IExecute;
+import com.jd.jdbc.VcursorImpl;
+import com.jd.jdbc.context.IContext;
+import com.jd.jdbc.engine.AbstractMultiQueryEngine;
+import com.jd.jdbc.engine.DMLEngine;
+import com.jd.jdbc.engine.InsertEngine;
+import com.jd.jdbc.engine.PrimitiveEngine;
+import com.jd.jdbc.engine.Vcursor;
+import com.jd.jdbc.sqltypes.VtResultSet;
+import com.jd.jdbc.srvtopo.BindVariable;
+import com.jd.jdbc.srvtopo.BoundQuery;
+import com.jd.jdbc.srvtopo.ResolvedShard;
+import io.vitess.proto.Query;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TableQueryEngine extends AbstractMultiQueryEngine {
+
+    private final Map<String, String> shardTableLTMap;
+
+    public TableQueryEngine(List<PrimitiveEngine> primitiveEngineList, List<IExecute.ResolvedShardQuery> shardQueryList,
+                            List<Map<String, BindVariable>> bindVariableMapList, Map<String, String> shardTableLTMap) {
+        super(primitiveEngineList, shardQueryList, bindVariableMapList);
+        this.shardTableLTMap = shardTableLTMap;
+    }
+
+    @Override
+    public IExecute.ExecuteMultiShardResponse execute(IContext ctx, Vcursor vcursor, Map<String, BindVariable> bindVariableMap, boolean wantFields) throws SQLException {
+        // 1.reorganizeQuries
+        // resolvedShardQuery:
+        // originSql1---> shards---sqls1
+        // originSql2---> shards---sqls2
+        // originSql3---> shards---sqls3
+        // originSql4---> shards---sqls4
+        //            |
+        //            |
+        //            V
+        // rss      queries
+        // shard1 sql1;sql2;sql3;
+        // shard2       sql2;sql3;sql4
+        // shard3 sql1;       sql3;sql4
+        // shard4        sql2;sql3;
+        Map<ResolvedShard, List<BoundQuery>> resolvedShardListMap = getResolvedShardListMap();
+
+        List<ResolvedShard> rss;
+        List<List<BoundQuery>> queries;
+
+        // for transaction needed query, parallel is not suitable
+        if (this.needsTransaction() || ((VcursorImpl) vcursor).getSafeSession().inTransaction()) {
+            rss = new ArrayList<>(resolvedShardListMap.size());
+            queries = new ArrayList<>(resolvedShardListMap.size());
+            for (Map.Entry<ResolvedShard, List<BoundQuery>> rssQueriesEntry : resolvedShardListMap.entrySet()) {
+                rss.add(rssQueriesEntry.getKey());
+                queries.add(rssQueriesEntry.getValue());
+            }
+        } else {
+            int maxParallelNum = vcursor.getMaxParallelNum();
+            int maxRssSize = resolvedShardListMap.size() * maxParallelNum;
+            rss = new ArrayList<>(maxRssSize);
+            queries = new ArrayList<>(maxRssSize);
+            for (Map.Entry<ResolvedShard, List<BoundQuery>> rssQueriesEntry : resolvedShardListMap.entrySet()) {
+                int partitionSize = (rssQueriesEntry.getValue().size() / maxParallelNum) + ((rssQueriesEntry.getValue().size() % maxParallelNum) > 0 ? 1 : 0);
+                List<List<BoundQuery>> rssQueries = Lists.partition(rssQueriesEntry.getValue(), partitionSize);
+                for (int i = 0; i < rssQueries.size(); i++) {
+                    rss.add(rssQueriesEntry.getKey());
+                }
+                queries.addAll(rssQueries);
+            }
+        }
+
+        // 2.parallelToShards
+        IExecute.ExecuteBatchMultiShardResponse response = parallelShardsExecute(vcursor, rss, queries);
+
+        // 3.getQuriesResult
+        List<List<VtResultSet>> vtResultSetList = response.getVtResultSetList();
+        List<ResolvedShard> resulRss = response.getRss();
+
+        // 4.merge results
+        VtResultSet resultSet = new VtResultSet();
+        for (int i = 0; i < resulRss.size(); i++) {
+            IExecute.ExecuteBatchResultSet batchResultSet = new IExecute.ExecuteBatchResultSet(vtResultSetList.get(i));
+            for (VtResultSet innerResult : batchResultSet.getVtResultSetList()) {
+                resultSet.appendResultIgnoreTable(innerResult);
+            }
+        }
+
+        // 5.modify field info
+        if (isDmlEngine()) {
+            return new IExecute.ExecuteMultiShardResponse(resultSet).setUpdate();
+        }
+
+        for (int i = 0; i < resultSet.getFields().length; i++) {
+            Query.Field[] fields = resultSet.getFields();
+            if (fields[i] == null) {
+                continue;
+            }
+            String actualTableName = fields[i].getTable();
+            if (shardTableLTMap.containsKey(actualTableName)) {
+                String logicTable = shardTableLTMap.get(actualTableName);
+                fields[i] = fields[i].toBuilder().setTable(logicTable).build();
+            }
+        }
+
+        return new IExecute.ExecuteMultiShardResponse(resultSet);
+    }
+
+    private boolean isDmlEngine() {
+        for (PrimitiveEngine primitiveEngine : primitiveEngineList) {
+            if (primitiveEngine instanceof DMLEngine
+                || primitiveEngine instanceof TableDMLEngine
+                || primitiveEngine instanceof InsertEngine
+                || primitiveEngine instanceof TableInsertEngine) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/jd/jdbc/planbuilder/MultiQueryPlan.java
+++ b/src/main/java/com/jd/jdbc/planbuilder/MultiQueryPlan.java
@@ -19,6 +19,7 @@ package com.jd.jdbc.planbuilder;
 import com.jd.jdbc.IExecute;
 import com.jd.jdbc.engine.MultiQueryEngine;
 import com.jd.jdbc.engine.PrimitiveEngine;
+import com.jd.jdbc.engine.table.TableQueryEngine;
 import com.jd.jdbc.srvtopo.BindVariable;
 import java.util.List;
 import java.util.Map;
@@ -30,5 +31,12 @@ public class MultiQueryPlan {
                                                       List<IExecute.ResolvedShardQuery> shardQueryList,
                                                       List<Map<String, BindVariable>> bindVariableMapList) {
         return new MultiQueryEngine(primitiveEngines, shardQueryList, bindVariableMapList);
+    }
+
+    public static PrimitiveEngine buildTableQueryPlan(List<PrimitiveEngine> primitiveEngines,
+                                                      List<IExecute.ResolvedShardQuery> shardQueryList,
+                                                      List<Map<String, BindVariable>> bindVariableMapList,
+                                                      Map<String, String> shardTableLTMap) {
+        return new TableQueryEngine(primitiveEngines, shardQueryList, bindVariableMapList, shardTableLTMap);
     }
 }

--- a/src/main/java/com/jd/jdbc/session/SafeSession.java
+++ b/src/main/java/com/jd/jdbc/session/SafeSession.java
@@ -18,6 +18,8 @@ limitations under the License.
 
 package com.jd.jdbc.session;
 
+import com.jd.jdbc.common.Constant;
+import com.jd.jdbc.sqlparser.utils.Utils;
 import com.jd.jdbc.vitess.VitessConnection;
 import com.jd.jdbc.vitess.mysql.VitessPropertyKey;
 import io.vitess.proto.Query;
@@ -309,6 +311,19 @@ public class SafeSession {
         }
 
         return this.vitessConnection.getProperties().getProperty(VitessPropertyKey.CHARACTER_ENCODING.getKeyName());
+    }
+
+    public int getMaxParallelNum() {
+        if (this.vitessConnection == null) {
+            return 1;
+        }
+
+        if (this.vitessConnection.getProperties() == null) {
+            return 1;
+        }
+
+        int maxParallel = Utils.getInteger(this.vitessConnection.getProperties(), Constant.DRIVER_PROPERTY_QUERY_PARALLEL_NUM, 1);
+        return maxParallel > 0 ? maxParallel : 1;
     }
 
     /**

--- a/src/main/java/com/jd/jdbc/sqlparser/utils/Utils.java
+++ b/src/main/java/com/jd/jdbc/sqlparser/utils/Utils.java
@@ -16,8 +16,18 @@
 
 package com.jd.jdbc.sqlparser.utils;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
@@ -29,13 +39,11 @@ public class Utils {
 
     public final static int DEFAULT_BUFFER_SIZE = 1024 * 4;
 
+    private static Date startTime;
+
     public static String read(InputStream in) {
         InputStreamReader reader;
-        try {
-            reader = new InputStreamReader(in, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        reader = new InputStreamReader(in, StandardCharsets.UTF_8);
         return read(reader);
     }
 
@@ -179,6 +187,11 @@ public class Utils {
         return null;
     }
 
+    public static Integer getInteger(Properties properties, String key, int defaultValue) {
+        Integer result = getInteger(properties, key);
+        return result != null ? result : defaultValue;
+    }
+
     public static Long getLong(Properties properties, String key) {
         String property = properties.getProperty(key);
 
@@ -218,8 +231,6 @@ public class Utils {
         return clazz;
     }
 
-    private static Date startTime;
-
     public final static Date getStartTime() {
         if (startTime == null) {
             startTime = new Date(ManagementFactory.getRuntimeMXBean().getStartTime());
@@ -249,13 +260,13 @@ public class Utils {
         for (int i = 0; i < length8; i++) {
             final int i8 = i * 8;
             long k = ((long) data[i8 + 0] & 0xff) //
-                    + (((long) data[i8 + 1] & 0xff) << 8) //
-                    + (((long) data[i8 + 2] & 0xff) << 16)//
-                    + (((long) data[i8 + 3] & 0xff) << 24) //
-                    + (((long) data[i8 + 4] & 0xff) << 32)//
-                    + (((long) data[i8 + 5] & 0xff) << 40)//
-                    + (((long) data[i8 + 6] & 0xff) << 48) //
-                    + (((long) data[i8 + 7] & 0xff) << 56);
+                + (((long) data[i8 + 1] & 0xff) << 8) //
+                + (((long) data[i8 + 2] & 0xff) << 16)//
+                + (((long) data[i8 + 3] & 0xff) << 24) //
+                + (((long) data[i8 + 4] & 0xff) << 32)//
+                + (((long) data[i8 + 5] & 0xff) << 40)//
+                + (((long) data[i8 + 6] & 0xff) << 48) //
+                + (((long) data[i8 + 7] & 0xff) << 56);
 
             k *= m;
             k ^= k >>> r;
@@ -279,10 +290,9 @@ public class Utils {
             case 2:
                 h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
             case 1:
-                h ^= (long) (data[length & ~7] & 0xff);
+                h ^= data[length & ~7] & 0xff;
                 h *= m;
         }
-        ;
 
         h ^= h >>> r;
         h *= m;

--- a/src/main/java/com/jd/jdbc/sqlparser/visitor/VtVisitor.java
+++ b/src/main/java/com/jd/jdbc/sqlparser/visitor/VtVisitor.java
@@ -48,9 +48,11 @@ import static com.jd.jdbc.sqltypes.SqlTypes.valueBindVariable;
 
 @Getter
 public class VtVisitor extends SQLASTVisitorAdapter {
-    private static final Log log = LogFactory.getLog(VtVisitor.class);
     public static final String BIND_VAR_PREFIX = "__vtg";
+
     public static final String BIND_VAR_PREFIX_WITH_COLON = ":__vtg";
+
+    private static final Log log = LogFactory.getLog(VtVisitor.class);
 
     private final String vIndex;
 
@@ -330,7 +332,7 @@ public class VtVisitor extends SQLASTVisitorAdapter {
                 }
 
                 Set<SQLExpr> interset = intersection(null == left ? null : Sets.newHashSet(left),
-                        null == right ? null : Sets.newHashSet(right));
+                    null == right ? null : Sets.newHashSet(right));
                 if (null == interset) {
                     return null;
                 }

--- a/src/main/java/com/jd/jdbc/vitess/VitessConnection.java
+++ b/src/main/java/com/jd/jdbc/vitess/VitessConnection.java
@@ -19,6 +19,7 @@ limitations under the License.
 package com.jd.jdbc.vitess;
 
 import com.jd.jdbc.VSchemaManager;
+import com.jd.jdbc.common.Constant;
 import com.jd.jdbc.context.IContext;
 import com.jd.jdbc.context.VtContext;
 import com.jd.jdbc.pool.InnerConnection;
@@ -55,8 +56,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 import lombok.Setter;
-
-import static com.jd.jdbc.common.Constant.DRIVER_PROPERTY_ROLE_KEY;
 
 public class VitessConnection extends AbstractVitessConnection {
     public static final Integer MAX_MEMORY_ROWS = 300000;
@@ -108,7 +107,7 @@ public class VitessConnection extends AbstractVitessConnection {
         this.executor = com.jd.jdbc.Executor.getInstance(Utils.getInteger(prop, "vtPlanCacheCapacity"));
         this.vm = vSchemaManager;
         this.ctx = VtContext.withCancel(VtContext.background());
-        this.ctx.setContextValue(DRIVER_PROPERTY_ROLE_KEY, VitessJdbcProperyUtil.getTabletType(prop));
+        this.ctx.setContextValue(Constant.DRIVER_PROPERTY_ROLE_KEY, VitessJdbcProperyUtil.getTabletType(prop));
         this.ctx.setContextValue(ContextKey.CTX_TOPOSERVER, topoServer);
         this.ctx.setContextValue(ContextKey.CTX_SCATTER_CONN, resolver.getScatterConn());
         this.ctx.setContextValue(ContextKey.CTX_TX_CONN, resolver.getScatterConn().getTxConn());

--- a/src/test/java/com/jd/jdbc/table/TestParallelQuery.java
+++ b/src/test/java/com/jd/jdbc/table/TestParallelQuery.java
@@ -1,0 +1,69 @@
+package com.jd.jdbc.table;
+
+import com.jd.jdbc.session.SafeSession;
+import com.jd.jdbc.vitess.VitessConnection;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import testsuite.TestSuite;
+
+import static testsuite.internal.TestSuiteShardSpec.TWO_SHARDS;
+
+public class TestParallelQuery extends TestSuite {
+
+    @Test
+    public void testSetParallelParams() {
+        String baseUrl = getConnectionUrl(Driver.of(TWO_SHARDS));
+        try (Connection conn = DriverManager.getConnection(baseUrl + "&queryParallelNum=0&vtMaximumPoolSize=30")) {
+            int maxParallelNum = SafeSession.newSafeSession((VitessConnection) conn).getMaxParallelNum();
+            Assert.assertEquals(1, maxParallelNum);
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+            Assert.fail();
+        }
+
+        try (Connection conn = DriverManager.getConnection(baseUrl)) {
+            int maxParallelNum = SafeSession.newSafeSession((VitessConnection) conn).getMaxParallelNum();
+            Assert.assertEquals(1, maxParallelNum);
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+            Assert.fail();
+        }
+
+        try (Connection conn = DriverManager.getConnection(baseUrl + "&queryParallelNum=8&vtMaximumPoolSize=30")) {
+            int maxParallelNum = SafeSession.newSafeSession((VitessConnection) conn).getMaxParallelNum();
+            Assert.assertEquals(8, maxParallelNum);
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testSplitTableParallelQuery() {
+        RandomStringUtils.random(10, 65, 123, true, true);
+        String query = "SELECT count(1) FROM pop_ware_ware ";
+
+        String baseUrl = getConnectionUrl(Driver.of(TWO_SHARDS));
+        baseUrl += "&queryParallelNum=1&vtMaximumPoolSize=30";
+        try (Connection conn = DriverManager.getConnection(baseUrl);
+             Statement stmt = conn.createStatement()) {
+            Long currentTime = System.currentTimeMillis();
+            ResultSet rs = stmt.executeQuery(query);
+            while (rs.next()) {
+                System.out.println("count: " + rs.getInt(1));
+            }
+            Long endTime = System.currentTimeMillis();
+            System.out.println(endTime - currentTime);
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/jd/jdbc/table/TransactionTest.java
+++ b/src/test/java/com/jd/jdbc/table/TransactionTest.java
@@ -16,10 +16,14 @@ limitations under the License.
 
 package com.jd.jdbc.table;
 
+import com.jd.jdbc.session.SafeSession;
+import com.jd.jdbc.vitess.VitessConnection;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -39,7 +43,9 @@ public class TransactionTest extends TestSuite {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
-    protected Connection conn;
+    protected String baseUrl;
+
+    protected List<Connection> connectionList;
 
     protected List<TransactionTestCase> transactionTestCaseList;
 
@@ -49,89 +55,109 @@ public class TransactionTest extends TestSuite {
     }
 
     protected void getConn() throws SQLException {
-        conn = getConnection(Driver.of(TestSuiteShardSpec.TWO_SHARDS));
+        baseUrl = getConnectionUrl(Driver.of(TestSuiteShardSpec.TWO_SHARDS));
+
+        Connection conn_0 = DriverManager.getConnection(baseUrl + "&queryParallelNum=0");
+        Connection conn_1 = DriverManager.getConnection(baseUrl + "&queryParallelNum=1");
+        Connection conn_8 = DriverManager.getConnection(baseUrl + "&queryParallelNum=2");
+        this.connectionList = new ArrayList<>();
+        this.connectionList.add(conn_0);
+        this.connectionList.add(conn_1);
+        this.connectionList.add(conn_8);
     }
 
     @After
     public void after() throws SQLException {
-        if (this.conn != null) {
-            this.conn.close();
+        if (this.connectionList != null) {
+            for (Connection conn : this.connectionList) {
+                if (conn != null) {
+                    conn.close();
+                }
+            }
         }
     }
 
     @Test
     public void test01() throws Exception {
-        TableTestUtil.setSplitTableConfig("engine/tableengine/split-table_1.yml", conn.getMetaData().getURL());
+        TableTestUtil.setSplitTableConfig("engine/tableengine/split-table_1.yml", baseUrl);
         this.transactionTestCaseList = iterateExecFile("src/test/resources/transaction/transaction/transaction_case.json", TransactionTestCase.class);
         testTx();
     }
 
     @Test
     public void test02() throws Exception {
-        TableTestUtil.setSplitTableConfig("engine/tableengine/split-table_2.yml", conn.getMetaData().getURL());
+        TableTestUtil.setSplitTableConfig("engine/tableengine/split-table_2.yml", baseUrl);
         this.transactionTestCaseList = iterateExecFile("src/test/resources/transaction/transaction/transaction_case.json", TransactionTestCase.class);
         testTx();
     }
 
     @Test
     public void testCommitWhenAutocommitTrue() throws SQLException {
-        conn.setAutoCommit(true);
+        for (Connection conn : this.connectionList) {
+            conn.setAutoCommit(true);
 
-        expectedEx.expectMessage("Can't call commit when autocommit=true");
-        conn.commit();
+            expectedEx.expectMessage("Can't call commit when autocommit=true");
+            conn.commit();
+        }
     }
 
     @Test
     public void testRollbackWhenAutocommitTrue() throws SQLException {
-        conn.setAutoCommit(true);
+        for (Connection conn : this.connectionList) {
+            conn.setAutoCommit(true);
 
-        expectedEx.expectMessage("Can't call rollback when autocommit=true");
-        conn.rollback();
+            expectedEx.expectMessage("Can't call rollback when autocommit=true");
+            conn.rollback();
+        }
     }
 
     private void testTx() throws SQLException {
         for (int index = 0; index < transactionTestCaseList.size(); index++) {
             TransactionTestCase testCase = transactionTestCaseList.get(index);
-            try (Statement stmt = conn.createStatement()) {
-                for (String init : testCase.initSql) {
-                    stmt.executeUpdate(init);
+            for (Connection conn : this.connectionList) {
+                int maxParallelNum = SafeSession.newSafeSession((VitessConnection) conn).getMaxParallelNum();
+                System.out.println("parallel num:" + maxParallelNum);
+                try (Statement stmt = conn.createStatement()) {
+                    for (String init : testCase.initSql) {
+                        stmt.executeUpdate(init);
+                    }
                 }
-            }
-            printComment(testCase.getComment());
-            if (testCase.getNeedTransaction()) {
-                conn.setAutoCommit(false);
-            }
-            try (Statement stmt = conn.createStatement()) {
-                for (String executeSql : testCase.executeSqls) {
-                    printNormal("No." + (index + 1) + " " + executeSql);
-                    stmt.executeUpdate(executeSql);
-                }
+                printComment(testCase.getComment());
                 if (testCase.getNeedTransaction()) {
-                    conn.commit();
-                    conn.setAutoCommit(true);
+                    conn.setAutoCommit(false);
                 }
-            } catch (Exception e) {
-                Assert.assertTrue(printFail("wrong errorMessage,error message: " + e.getMessage()), e.getMessage().contains(testCase.errorMsg));
-                if (testCase.getNeedTransaction()) {
-                    conn.rollback();
-                    conn.setAutoCommit(true);
+                try (Statement stmt = conn.createStatement()) {
+                    for (String executeSql : testCase.executeSqls) {
+                        printNormal("No." + (index + 1) + " " + executeSql);
+                        stmt.executeUpdate(executeSql);
+                    }
+                    if (testCase.getNeedTransaction()) {
+                        conn.commit();
+                        conn.setAutoCommit(true);
+                    }
+                } catch (Exception e) {
+                    if (testCase.getNeedTransaction()) {
+                        conn.rollback();
+                        conn.setAutoCommit(true);
+                    }
+                    Assert.assertTrue(e.getMessage().contains(testCase.getErrorMsg()));
                 }
-            }
-            try (Statement stmt = conn.createStatement()) {
-                for (String sql : testCase.verfiySql) {
-                    ResultSet rs = stmt.executeQuery(sql);
-                    while (rs.next()) {
-                        for (int i = 0; i < testCase.verfiyResult.length; i++) {
-                            Object[] expectArray = testCase.verfiyResult[i];
-                            for (int j = 0; j < expectArray.length; j++) {
-                                if (expectArray[j] instanceof Integer) {
-                                    Assert.assertEquals(printFail("Failed"), expectArray[j], rs.getInt(j + 1));
+                try (Statement stmt = conn.createStatement()) {
+                    for (String sql : testCase.verfiySql) {
+                        ResultSet rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            for (int i = 0; i < testCase.verfiyResult.length; i++) {
+                                Object[] expectArray = testCase.verfiyResult[i];
+                                for (int j = 0; j < expectArray.length; j++) {
+                                    if (expectArray[j] instanceof Integer) {
+                                        Assert.assertEquals(printFail("Failed"), expectArray[j], rs.getInt(j + 1));
+                                    }
                                 }
                             }
                         }
                     }
+                    printOk("No." + (index + 1) + " [Successed] \n");
                 }
-                printOk("No." + (index + 1) + " [Successed] \n");
             }
         }
     }

--- a/src/test/java/com/jd/jdbc/table/engine/unshard/SelectUnShardTest.java
+++ b/src/test/java/com/jd/jdbc/table/engine/unshard/SelectUnShardTest.java
@@ -17,14 +17,24 @@ limitations under the License.
 package com.jd.jdbc.table.engine.unshard;
 
 import com.jd.jdbc.table.engine.SelectTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import testsuite.internal.TestSuiteShardSpec;
 
 public class SelectUnShardTest extends SelectTest {
 
     @Override
     protected void getConn() throws SQLException {
-        conn = getConnection(Driver.of(TestSuiteShardSpec.NO_SHARDS));
+        baseUrl = getConnectionUrl(Driver.of(TestSuiteShardSpec.NO_SHARDS));
+        Connection conn_0 = DriverManager.getConnection(baseUrl + "&queryParallelNum=0");
+        Connection conn_1 = DriverManager.getConnection(baseUrl + "&queryParallelNum=1");
+        Connection conn_8 = DriverManager.getConnection(baseUrl + "&queryParallelNum=2");
+        this.connectionList = new ArrayList<>();
+        this.connectionList.add(conn_0);
+        this.connectionList.add(conn_1);
+        this.connectionList.add(conn_8);
     }
 
     @Override

--- a/src/test/java/com/jd/jdbc/table/unshard/TransactionUnShardTest.java
+++ b/src/test/java/com/jd/jdbc/table/unshard/TransactionUnShardTest.java
@@ -17,13 +17,23 @@ limitations under the License.
 package com.jd.jdbc.table.unshard;
 
 import com.jd.jdbc.table.TransactionTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import testsuite.internal.TestSuiteShardSpec;
 
 public class TransactionUnShardTest extends TransactionTest {
 
     @Override
     protected void getConn() throws SQLException {
-        conn = getConnection(Driver.of(TestSuiteShardSpec.NO_SHARDS));
+        baseUrl = getConnectionUrl(Driver.of(TestSuiteShardSpec.NO_SHARDS));
+        Connection conn_0 = DriverManager.getConnection(baseUrl + "&queryParallelNum=0");
+        Connection conn_1 = DriverManager.getConnection(baseUrl + "&queryParallelNum=1");
+        Connection conn_8 = DriverManager.getConnection(baseUrl + "&queryParallelNum=2");
+        this.connectionList = new ArrayList<>();
+        this.connectionList.add(conn_0);
+        this.connectionList.add(conn_1);
+        this.connectionList.add(conn_8);
     }
 }

--- a/src/test/resources/engine/tableengine/select_case.json
+++ b/src/test/resources/engine/tableengine/select_case.json
@@ -214,7 +214,7 @@
       "delete from table_engine_test",
       "insert into table_engine_test(id,f_key,f_tinyint,f_bit) values(1,'11',0,true),(2,'11',1,false),(3,'11',2,true),(7,'11',5,true),(8,'12',8,false),(9,'43',127,true),(4,'12',-1,true),(5,'11',3,false),(6,'14',6,true)"
     ],
-    "query": "select * from table_engine_test where (f_key ='11') AND f_bit = true limit 2",
+    "query": "select id, f_key, f_tinyint, f_bit from table_engine_test where (f_key ='11') AND f_bit = true order by id limit 2",
     "fields": [
       {
         "name": "id",
@@ -646,7 +646,7 @@
       "delete from table_engine_test",
       "insert into table_engine_test(id,f_key,f_tinyint,f_bit) values(1,'11',0,true),(2,'11',1,false),(3,'11',2,true),(7,'11',5,true),(8,'12',8,false),(9,'43',127,true),(4,'12',-1,true),(5,'11',3,false),(6,'14',6,true)"
     ],
-    "query": "select * from table_engine_test where (f_key ='11') AND f_bit = true limit 2;",
+    "query": "select ID, F_KEY, F_TINYINT, F_BIT from table_engine_test where (f_key ='11') AND f_bit = true order by id limit 2;",
     "fields": [
       {
         "name": "id",

--- a/src/test/resources/engine/tableengine/select_case_upperCase.json
+++ b/src/test/resources/engine/tableengine/select_case_upperCase.json
@@ -214,7 +214,7 @@
       "delete from table_engine_test",
       "insert into table_engine_test(id,f_key,f_tinyint,f_bit) values(1,'11',0,true),(2,'11',1,false),(3,'11',2,true),(7,'11',5,true),(8,'12',8,false),(9,'43',127,true),(4,'12',-1,true),(5,'11',3,false),(6,'14',6,true)"
     ],
-    "query": "SELECT * FROM TABLE_ENGINE_TEST WHERE (F_KEY ='11') AND F_BIT = TRUE LIMIT 2",
+    "query": "SELECT ID, F_KEY, F_TINYINT, F_BIT FROM TABLE_ENGINE_TEST WHERE (F_KEY ='11') AND F_BIT = TRUE order by id LIMIT 2",
     "fields": [
       {
         "name": "id",


### PR DESCRIPTION
Before this pr, a query for a partitioned table will be rewritten to multi sqls (only tablename is different) to one shard. And these SQLs will be sent to a shard as a batch. MySQL executes this batch of sqls one by one. 

If we can split this batch into multi batches and send them to one shard parallelly, execution time may be shortened because MySQL executes these requirements parallelly.